### PR TITLE
TGP-377: Implement Missing Validations - QA Fixes

### DIFF
--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/CreateRecordRequest.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/CreateRecordRequest.scala
@@ -21,7 +21,6 @@ import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.Reads.verifying
 import play.api.libs.json.{JsPath, OWrites, Reads}
 import uk.gov.hmrc.tradergoodsprofilesrouter.models.response.eis.Assessment
-import uk.gov.hmrc.tradergoodsprofilesrouter.utils.ValidationSupport
 import uk.gov.hmrc.tradergoodsprofilesrouter.utils.ValidationSupport.Reads.lengthBetween
 import uk.gov.hmrc.tradergoodsprofilesrouter.utils.ValidationSupport.isValidCountryCode
 
@@ -52,7 +51,7 @@ object CreateRecordRequest {
       (JsPath \ "comcode").read(lengthBetween(6, 10)) and
       (JsPath \ "goodsDescription").read(lengthBetween(1, 512)) and
       (JsPath \ "countryOfOrigin").read(lengthBetween(1, 2).andKeep(verifying(isValidCountryCode))) and
-      (JsPath \ "category").read[Int] and
+      (JsPath \ "category").read[Int](verifying[Int](category => category >= 1 && category <= 3)) and
       (JsPath \ "assessments").readNullable[Seq[Assessment]] and
       (JsPath \ "supplementaryUnit").readNullable[Int] and
       (JsPath \ "measurementUnit").readNullable[String] and

--- a/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/CreateRecordIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/CreateRecordIntegrationSpec.scala
@@ -527,6 +527,29 @@ class CreateRecordIntegrationSpec extends BaseIntegrationWithConnectorSpec with 
 
           verifyThatDownstreamApiWasNotCalled()
         }
+        "category field is out of range" in {
+          val response = wsClient
+            .url(fullUrl(s"/records/"))
+            .withHttpHeaders(("Content-Type", "application/json"), ("X-Client-ID", "tss"))
+            .post(invalidCategoryRequestData)
+            .futureValue
+
+          response.status shouldBe BAD_REQUEST
+          response.json   shouldBe Json.obj(
+            "correlationId" -> correlationId,
+            "code"          -> "BAD_REQUEST",
+            "message"       -> "Bad Request",
+            "errors"        -> Json.arr(
+              Json.obj(
+                "code"        -> "INVALID_REQUEST_PARAMETER",
+                "message"     -> "Mandatory field category was missing from body or is in the wrong format",
+                "errorNumber" -> 14
+              )
+            )
+          )
+
+          verifyThatDownstreamApiWasNotCalled()
+        }
       }
     }
   }
@@ -674,6 +697,35 @@ class CreateRecordIntegrationSpec extends BaseIntegrationWithConnectorSpec with 
       |    "goodsDescription": "Organic bananas",
       |    "countryOfOrigin": "EC",
       |    "category": 1,
+      |    "assessments": [
+      |        {
+      |            "assessmentId": "abc123",
+      |            "primaryCategory": 1,
+      |            "condition": {
+      |                "type": "abc123",
+      |                "conditionId": "Y923",
+      |                "conditionDescription": "Products not considered as waste according to Regulation (EC) No 1013/2006 as retained in UK law",
+      |                "conditionTraderText": "Excluded product"
+      |            }
+      |        }
+      |    ],
+      |    "supplementaryUnit": 500,
+      |    "measurementUnit": "Square metre (m2)",
+      |    "comcodeEffectiveFromDate": "2024-11-18T23:20:19Z",
+      |    "comcodeEffectiveToDate": "2024-11-18T23:20:19Z"
+      |}
+      |""".stripMargin
+
+  lazy val invalidCategoryRequestData: String =
+    """
+      |{
+      |  "eori": "GB123456789012",
+      |    "actorId": "GB098765432112",
+      |    "traderRef": "BAN001001",
+      |    "comcode": "104101000",
+      |    "goodsDescription": "Organic bananas",
+      |    "countryOfOrigin": "EC",
+      |    "category": 24,
       |    "assessments": [
       |        {
       |            "assessmentId": "abc123",

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/controllers/CreateRecordControllerSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/controllers/CreateRecordControllerSpec.scala
@@ -116,6 +116,35 @@ class CreateRecordControllerSpec extends PlaySpec with MockitoSugar {
       status(result) mustBe BAD_REQUEST
       contentAsJson(result) mustBe Json.toJson(errorResponse)
     }
+
+    "return 400 Bad request when category is out of range" in {
+
+      val errorResponse = ErrorResponse(
+        "8ebb6b04-6ab0-4fe2-ad62-e6389a8a204f",
+        ApplicationConstants.BadRequestCode,
+        ApplicationConstants.BadRequestMessage,
+        Some(
+          Seq(
+            Error(
+              "INVALID_REQUEST_PARAMETER",
+              "Mandatory field category was missing from body or is in the wrong format",
+              14
+            )
+          )
+        )
+      )
+
+      when(mockUuidService.uuid).thenReturn("8ebb6b04-6ab0-4fe2-ad62-e6389a8a204f")
+      val result = sut.create(
+        FakeRequest().withBody(outOfRangeCategoryRequestData).withHeaders(validHeaders: _*)
+      )
+
+      status(result) mustBe BAD_REQUEST
+
+      withClue("should return json response") {
+        contentAsJson(result) mustBe Json.toJson(errorResponse)
+      }
+    }
   }
 
   lazy val createRecordResponseData: CreateOrUpdateRecordResponse = Json
@@ -216,4 +245,33 @@ class CreateRecordControllerSpec extends PlaySpec with MockitoSugar {
         |    "comcodeEffectiveToDate": "2024-11-18T23:20:19Z"
         |}
         |""".stripMargin)
+
+  lazy val outOfRangeCategoryRequestData: JsValue = Json
+    .parse("""
+             |{
+             |    "eori": "GB123456789012",
+             |    "actorId": "GB098765432112",
+             |    "traderRef": "BAN001001",
+             |    "comcode": "104101000",
+             |    "goodsDescription": "Organic bananas",
+             |    "countryOfOrigin": "EC",
+             |    "category": 24,
+             |    "assessments": [
+             |        {
+             |            "assessmentId": "abc123",
+             |            "primaryCategory": 1,
+             |            "condition": {
+             |                "type": "abc123",
+             |                "conditionId": "Y923",
+             |                "conditionDescription": "Products not considered as waste according to Regulation (EC) No 1013/2006 as retained in UK law",
+             |                "conditionTraderText": "Excluded product"
+             |            }
+             |        }
+             |    ],
+             |    "supplementaryUnit": 500,
+             |    "measurementUnit": "Square metre (m2)",
+             |    "comcodeEffectiveFromDate": "2024-11-18T23:20:19Z",
+             |    "comcodeEffectiveToDate": "2024-11-18T23:20:19Z"
+             |}
+             |""".stripMargin)
 }

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/CreateRecordRequestSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/CreateRecordRequestSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tradergoodsprofilesrouter.models.request
+
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.Json
+
+class CreateRecordRequestSpec extends PlaySpec {
+
+  "CreateRecordRequest validation" should {
+
+    "validate category within range 1 to 3" in {
+      val validJson1 = Json.parse("""
+          |{
+          |  "eori": "GB123456789012",
+          |  "actorId": "GB987654321098",
+          |  "traderRef": "SKU123456",
+          |  "comcode": "123456",
+          |  "goodsDescription": "Bananas",
+          |  "countryOfOrigin": "GB",
+          |  "category": 1,
+          |  "comcodeEffectiveFromDate": "2023-01-01T00:00:00Z"
+          |}
+        """.stripMargin)
+
+      val validJson2 = Json.parse("""
+          |{
+          |  "eori": "GB123456789012",
+          |  "actorId": "GB987654321098",
+          |  "traderRef": "SKU123456",
+          |  "comcode": "123456",
+          |  "goodsDescription": "Bananas",
+          |  "countryOfOrigin": "GB",
+          |  "category": 2,
+          |  "comcodeEffectiveFromDate": "2023-01-01T00:00:00Z"
+          |}
+        """.stripMargin)
+
+      val validJson3 = Json.parse("""
+          |{
+          |  "eori": "GB123456789012",
+          |  "actorId": "GB987654321098",
+          |  "traderRef": "SKU123456",
+          |  "comcode": "123456",
+          |  "goodsDescription": "Bananas",
+          |  "countryOfOrigin": "GB",
+          |  "category": 3,
+          |  "comcodeEffectiveFromDate": "2023-01-01T00:00:00Z"
+          |}
+        """.stripMargin)
+
+      val invalidJson = Json.parse("""
+          |{
+          |  "eori": "GB123456789012",
+          |  "actorId": "GB987654321098",
+          |  "traderRef": "SKU123456",
+          |  "comcode": "123456",
+          |  "goodsDescription": "Bananas",
+          |  "countryOfOrigin": "GB",
+          |  "category": 24,
+          |  "comcodeEffectiveFromDate": "2023-01-01T00:00:00Z"
+          |}
+        """.stripMargin)
+
+      validJson1.validate[CreateRecordRequest].isSuccess mustBe true
+      validJson2.validate[CreateRecordRequest].isSuccess mustBe true
+      validJson3.validate[CreateRecordRequest].isSuccess mustBe true
+      invalidJson.validate[CreateRecordRequest].isError mustBe true
+    }
+  }
+}


### PR DESCRIPTION
- [x] Implemented validation for `category` field to accept only integer values from `1` to `3`. Included related unit and integration tests. 




---
**Ticket:** [TGP-377](https://jira.tools.tax.service.gov.uk/browse/TGP-377)