### PR TITLE
TGP-1530: Add actorId to router RequestAdvice object and adjust the t…

### DIFF
--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/RequestAdvice.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/RequestAdvice.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.tradergoodsprofilesrouter.controllers.action.ValidationRules.
 import scala.Function.unlift
 
 case class RequestAdvice(
+  actorId: String,
   requestorName: String,
   requestorEmail: String
 )
@@ -30,11 +31,11 @@ case class RequestAdvice(
 object RequestAdvice {
 
   implicit val reads: Reads[RequestAdvice] =
-    ((JsPath \ "requestorName").read(lengthBetween(1, 70)) and
+    ((JsPath \ "actorId").read(lengthBetween(14, 17)) and (JsPath \ "requestorName").read(lengthBetween(1, 70)) and
       (JsPath \ "requestorEmail")
         .read(lengthBetween(3, 254).keepAnd(validEmailAddress)))(RequestAdvice.apply _)
 
   implicit lazy val writes: OWrites[RequestAdvice] =
-    ((JsPath \ "requestorName").write[String] and
+    ((JsPath \ "actorId").write[String] and (JsPath \ "requestorName").write[String] and
       (JsPath \ "requestorEmail").write[String])(unlift(RequestAdvice.unapply))
 }

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/service/RequestAdviceService.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/service/RequestAdviceService.scala
@@ -122,7 +122,7 @@ class RequestAdviceService @Inject() (
     val traderDetails = TraderDetails(
       eori,
       request.requestorName,
-      Some(goodsItemRecords.actorId),
+      Some(request.actorId),
       request.requestorEmail,
       goodsItemRecords.ukimsNumber,
       Seq(goodsItem)

--- a/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/RequestAdviceIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/RequestAdviceIntegrationSpec.scala
@@ -482,7 +482,7 @@ class RequestAdviceIntegrationSpec
       |         "traderDetails":{
       |            "traderEORI":"GB123456789001",
       |            "requestorName":"Mr.Phil Edwards",
-      |            "requestorEORI":"GB1234567890",
+      |            "requestorEORI":"GB9876543210983",
       |            "requestorEmail":"Phil.Edwards@gmail.com",
       |            "ukimsAuthorisation":"XIUKIM47699357400020231115081800",
       |            "goodsItems":[
@@ -506,6 +506,7 @@ class RequestAdviceIntegrationSpec
   private def requestAdviceData: String =
     s"""
              |{
+             |    "actorId": "GB9876543210983",
              |    "requestorName": "Mr.Phil Edwards",
              |    "requestorEmail": "Phil.Edwards@gmail.com"
              |}

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/controllers/RequestAdviceControllerSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/controllers/RequestAdviceControllerSpec.scala
@@ -60,6 +60,7 @@ class RequestAdviceControllerSpec extends PlaySpec with MockitoSugar with GetRec
   private val requestAccreditationData = Json
     .parse("""
         |{
+        |    "actorId": "GB9876543210983",
         |    "requestorName": "Mr. Phil Edwards",
         |    "requestorEmail": "Phil.Edwards@gmail.com"
         |}
@@ -68,6 +69,7 @@ class RequestAdviceControllerSpec extends PlaySpec with MockitoSugar with GetRec
   private val invalidRequestAccreditationData = Json
     .parse("""
         |{
+        |    "actorId": "",
         |    "requestorName": "Mr. Phil Edwards",
         |    "requestorEmail": ""
         |}
@@ -134,6 +136,11 @@ class RequestAdviceControllerSpec extends PlaySpec with MockitoSugar with GetRec
               "INVALID_REQUEST_PARAMETER",
               "Mandatory field RequestorEmail was missing from body or is in the wrong format",
               38
+            ),
+            Error(
+              "INVALID_REQUEST_PARAMETER",
+              "Mandatory field actorId was missing from body or is in the wrong format",
+              8
             )
           )
         )

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/service/RequestAdviceServiceSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/service/RequestAdviceServiceSpec.scala
@@ -53,7 +53,7 @@ class RequestAdviceServiceSpec
   private val getRecordService = mock[GetRecordsService]
   private val uuidService      = mock[UuidService]
 
-  private val request = new RequestAdvice("Judi Dench", "judi@example.com")
+  private val request = new RequestAdvice("GB9876543210983", "Judi Dench", "judi@example.com")
 
   val service = new RequestAdviceService(connector, getRecordService, uuidService)
 


### PR DESCRIPTION
the actorId in the Get Record is the EORI of the last person to update that record, this is not necessarily the same as the EORI of the person making the Advice Request which is why I am adding back the actorId to the request body.