### PR TITLE
TGP-1585 Log messages must be at an appropriate level

### DIFF
--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/EisHttpReader.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/EisHttpReader.scala
@@ -54,14 +54,14 @@ object EisHttpReader {
           .validate[T]
           .map(result => result)
           .recoverTotal { error: JsError =>
-            logger.error(
+            logger.warn(
               s"[EisConnector] - Failed to validate or parse JSON body of type: ${typeOf[T]}",
               error
             )
             throw new RuntimeException(s"Response body could not be read as type ${typeOf[T]}")
           }
       case Failure(exception) =>
-        logger.error(
+        logger.warn(
           s"[EisConnector] - Response body could not be parsed as JSON, body: ${response.body}",
           exception
         )

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/controllers/action/AuthAction.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/controllers/action/AuthAction.scala
@@ -119,7 +119,7 @@ class AuthActionImpl @Inject() (
   }
 
   private def handleForbiddenError[A](eoriNumber: String)(implicit request: Request[A]): Future[Result] = {
-    logger.error(s"Forbidden error for ${request.uri}, eori number $eoriNumber")
+    logger.warn(s"Forbidden error for ${request.uri}, eori number $eoriNumber")
 
     Future.successful(
       Forbidden(
@@ -148,7 +148,7 @@ class AuthActionImpl @Inject() (
     errorMessage: String
   )(implicit request: Request[A]): Result = {
 
-    logger.error(s"Unauthorised exception for ${request.uri} with error $errorMessage")
+    logger.warn(s"Unauthorised exception for ${request.uri} with error $errorMessage")
 
     Unauthorized(
       Json.toJson(
@@ -165,7 +165,7 @@ class AuthActionImpl @Inject() (
     errorMessage: String
   )(implicit request: Request[A]): Result = {
 
-    logger.error(s"Unauthorised exception for ${request.uri} with error $errorMessage")
+    logger.warn(s"Unauthorised exception for ${request.uri} with error $errorMessage")
 
     Unauthorized(
       Json.toJson(


### PR DESCRIPTION
In keeping with the recommendations from this guide - [Logging best practices](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?spaceKey=DTRG&title=Logging+best+practices#:~:text=data%20is%20PII.-,Use%20the%20appropriate%20log%20level,-Error%20%2D%20for%20significant), I have updated all issues related to unexpected response to a warn level log and only kept the error level log when a failure occurs during the api call