### PR TITLE
TGP-1649: Split up EIS config into HAWK and PEGA

### DIFF
--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/config/AppConfig.scala
@@ -23,5 +23,6 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class AppConfig @Inject() (config: Configuration) {
 
-  val eisConfig: EISInstanceConfig = config.get[EISInstanceConfig]("microservice.services.eis")
+  val hawkConfig: HawkInstanceConfig = config.get[HawkInstanceConfig]("microservice.services.hawk")
+  val pegaConfig: PegaInstanceConfig = config.get[PegaInstanceConfig]("microservice.services.pega")
 }

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/config/HawkInstanceConfig.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/config/HawkInstanceConfig.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tradergoodsprofilesrouter.config
+
+import play.api.{ConfigLoader, Configuration}
+
+case class HawkInstanceConfig(
+  protocol: String,
+  host: String,
+  port: Int,
+  getRecords: String,
+  createRecord: String,
+  removeRecord: String,
+  updateRecord: String,
+  maintainProfile: String,
+  forwardedHost: String,
+  updateRecordToken: String,
+  recordGetToken: String,
+  recordCreateToken: String,
+  recordRemoveToken: String,
+  maintainProfileToken: String
+) {
+  lazy val getRecordsUrl: String      = s"$protocol://$host:$port$getRecords"
+  lazy val createRecordUrl: String    = s"$protocol://$host:$port$createRecord"
+  lazy val removeRecordUrl: String    = s"$protocol://$host:$port$removeRecord"
+  lazy val updateRecordUrl: String    = s"$protocol://$host:$port$updateRecord"
+  lazy val maintainProfileUrl: String = s"$protocol://$host:$port$maintainProfile"
+
+  lazy val updateRecordBearerToken    = s"Bearer $updateRecordToken"
+  lazy val getRecordBearerToken       = s"Bearer $recordGetToken"
+  lazy val createRecordBearerToken    = s"Bearer $recordCreateToken"
+  lazy val removeRecordBearerToken    = s"Bearer $recordRemoveToken"
+  lazy val maintainProfileBearerToken = s"Bearer $maintainProfileToken"
+}
+
+object HawkInstanceConfig {
+
+  implicit lazy val configLoader: ConfigLoader[HawkInstanceConfig] =
+    ConfigLoader { rootConfig => path =>
+      val config: Configuration = Configuration(rootConfig.getConfig(path))
+      HawkInstanceConfig(
+        config.get[String]("protocol"),
+        config.get[String]("host"),
+        config.get[Int]("port"),
+        config.get[String]("get-records"),
+        config.get[String]("create-record"),
+        config.get[String]("remove-record"),
+        config.get[String]("update-record"),
+        config.get[String]("maintain-profile"),
+        config.get[String]("forwarded-host"),
+        config.getOptional[String]("record-update-token").getOrElse("dummyRecordUpdateBearerToken"),
+        config.getOptional[String]("record-get-token").getOrElse("dummyRecordGetBearerToken"),
+        config.getOptional[String]("record-create-token").getOrElse("dummyRecordCreateBearerToken"),
+        config.getOptional[String]("record-remove-token").getOrElse("dummyRecordRemoveBearerToken"),
+        config.getOptional[String]("maintain-profile-token").getOrElse("dummyMaintainProfileBearerToken")
+      )
+    }
+}

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/config/PegaInstanceConfig.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/config/PegaInstanceConfig.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.tradergoodsprofilesrouter.config
+
+import play.api.{ConfigLoader, Configuration}
+
+case class PegaInstanceConfig(
+  protocol: String,
+  host: String,
+  port: Int,
+  requestAdvice: String,
+  forwardedHost: String,
+  requestAdviceToken: String
+) {
+  lazy val requestAdviceUrl: String = s"$protocol://$host:$port$requestAdvice"
+  lazy val requestAdviceBearerToken = s"Bearer $requestAdviceToken"
+}
+
+object PegaInstanceConfig {
+
+  implicit lazy val configLoader: ConfigLoader[PegaInstanceConfig] =
+    ConfigLoader { rootConfig => path =>
+      val config: Configuration = Configuration(rootConfig.getConfig(path))
+      PegaInstanceConfig(
+        config.get[String]("protocol"),
+        config.get[String]("host"),
+        config.get[Int]("port"),
+        config.get[String]("request-advice"),
+        config.get[String]("forwarded-host"),
+        config.getOptional[String]("request-advice-token").getOrElse("dummyRequestAdviceBearerToken")
+      )
+    }
+}

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/BaseConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/BaseConnector.scala
@@ -28,10 +28,12 @@ trait BaseConnector {
   def appConfig: AppConfig
   def dateTimeService: DateTimeService
 
-  def buildHeaders(correlationId: String, accessToken: String)(implicit hc: HeaderCarrier): Seq[(String, String)] =
+  protected def buildHeaders(correlationId: String, accessToken: String, forwardedHost: String)(implicit
+    hc: HeaderCarrier
+  ): Seq[(String, String)] =
     Seq(
       HeaderNames.CorrelationId -> correlationId,
-      HeaderNames.ForwardedHost -> appConfig.eisConfig.forwardedHost,
+      HeaderNames.ForwardedHost -> forwardedHost,
       HeaderNames.Accept        -> MimeTypes.JSON,
       HeaderNames.Date          -> dateTimeService.timestamp.asStringHttp,
       HeaderNames.ClientId      -> hc.headers(Seq(HeaderNames.ClientId)).head._2,
@@ -39,15 +41,13 @@ trait BaseConnector {
       HeaderNames.ContentType   -> MimeTypes.JSON
     )
 
-  def buildHeadersForGetMethod(correlationId: String, accessToken: String)(implicit
+  protected def buildHeadersForGetMethod(correlationId: String, accessToken: String, forwardedHost: String)(implicit
     hc: HeaderCarrier
   ): Seq[(String, String)] =
-    buildHeaders(correlationId, accessToken).filterNot(_._1 == HeaderNames.ContentType)
+    buildHeaders(correlationId, accessToken, forwardedHost).filterNot(_._1 == HeaderNames.ContentType)
 
-  def buildHeadersForAdvice(correlationId: String, bearerToken: String)(implicit
+  protected def buildHeadersForAdvice(correlationId: String, bearerToken: String, forwardedHost: String)(implicit
     hc: HeaderCarrier
   ): Seq[(String, String)] =
-    buildHeaders(correlationId, bearerToken).filterNot(elm =>
-      elm == HeaderNames.ClientId -> hc.headers(Seq(HeaderNames.ClientId)).head._2
-    )
+    buildHeaders(correlationId, bearerToken, forwardedHost).filterNot(_._1 == HeaderNames.ClientId)
 }

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/CreateRecordConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/CreateRecordConnector.scala
@@ -45,11 +45,17 @@ class CreateRecordConnector @Inject() (
     correlationId: String
   )(implicit hc: HeaderCarrier): Future[Either[EisHttpErrorResponse, CreateOrUpdateRecordResponse]] =
     withMetricsTimerAsync("tgp.createrecord.connector") { _ =>
-      val url = appConfig.eisConfig.createRecordUrl
+      val url = appConfig.hawkConfig.createRecordUrl
 
       httpClientV2
         .post(url"$url")
-        .setHeader(buildHeaders(correlationId, appConfig.eisConfig.createRecordBearerToken): _*)
+        .setHeader(
+          buildHeaders(
+            correlationId,
+            appConfig.hawkConfig.createRecordBearerToken,
+            appConfig.hawkConfig.forwardedHost
+          ): _*
+        )
         .withBody(Json.toJson(payload))
         .execute(HttpReader[CreateOrUpdateRecordResponse](correlationId, handleErrorResponse), ec)
     }

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/GetRecordsConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/GetRecordsConnector.scala
@@ -47,11 +47,17 @@ class GetRecordsConnector @Inject() (
     correlationId: String
   )(implicit hc: HeaderCarrier): Future[Either[EisHttpErrorResponse, GetEisRecordsResponse]] =
     withMetricsTimerAsync("tgp.getrecord.connector") { _ =>
-      val url = s"${appConfig.eisConfig.getRecordsUrl}/$eori/$recordId"
+      val url = s"${appConfig.hawkConfig.getRecordsUrl}/$eori/$recordId"
 
       httpClientV2
         .get(url"$url")
-        .setHeader(buildHeadersForGetMethod(correlationId, appConfig.eisConfig.getRecordBearerToken): _*)
+        .setHeader(
+          buildHeadersForGetMethod(
+            correlationId,
+            appConfig.hawkConfig.getRecordBearerToken,
+            appConfig.hawkConfig.forwardedHost
+          ): _*
+        )
         .execute(HttpReader[GetEisRecordsResponse](correlationId, handleErrorResponse), ec)
     }
 
@@ -65,11 +71,17 @@ class GetRecordsConnector @Inject() (
     withMetricsTimerAsync("tgp.getrecords.connector") { _ =>
       val formattedLastUpdateDate: Option[String] = lastUpdatedDate.map(_.asStringSeconds)
       val uri                                     =
-        uri"${appConfig.eisConfig.getRecordsUrl}/$eori?lastUpdatedDate=$formattedLastUpdateDate&page=$page&size=$size"
+        uri"${appConfig.hawkConfig.getRecordsUrl}/$eori?lastUpdatedDate=$formattedLastUpdateDate&page=$page&size=$size"
 
       httpClientV2
         .get(url"$uri")
-        .setHeader(buildHeadersForGetMethod(correlationId, appConfig.eisConfig.getRecordBearerToken): _*)
+        .setHeader(
+          buildHeadersForGetMethod(
+            correlationId,
+            appConfig.hawkConfig.getRecordBearerToken,
+            appConfig.hawkConfig.forwardedHost
+          ): _*
+        )
         .execute(HttpReader[GetEisRecordsResponse](correlationId, handleErrorResponse), ec)
     }
 

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/MaintainProfileConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/MaintainProfileConnector.scala
@@ -44,10 +44,16 @@ class MaintainProfileConnector @Inject() (
     hc: HeaderCarrier
   ): Future[Either[EisHttpErrorResponse, MaintainProfileResponse]] =
     withMetricsTimerAsync("tgp.maintainprofile.connector") { _ =>
-      val url = appConfig.eisConfig.maintainProfileUrl
+      val url = appConfig.hawkConfig.maintainProfileUrl
       httpClientV2
         .put(url"$url")
-        .setHeader(buildHeaders(correlationId, appConfig.eisConfig.maintainProfileBearerToken): _*)
+        .setHeader(
+          buildHeaders(
+            correlationId,
+            appConfig.hawkConfig.maintainProfileBearerToken,
+            appConfig.hawkConfig.forwardedHost
+          ): _*
+        )
         .withBody(Json.toJson(request))
         .execute(HttpReader[MaintainProfileResponse](correlationId, handleErrorResponse), ec)
     }

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/RemoveRecordConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/RemoveRecordConnector.scala
@@ -46,10 +46,16 @@ class RemoveRecordConnector @Inject() (
     correlationId: String
   )(implicit hc: HeaderCarrier): Future[Either[EisHttpErrorResponse, Int]] =
     withMetricsTimerAsync("tgp.removerecord.connector") { _ =>
-      val url = appConfig.eisConfig.removeRecordUrl
+      val url = appConfig.hawkConfig.removeRecordUrl
       httpClientV2
         .put(url"$url")
-        .setHeader(buildHeaders(correlationId, appConfig.eisConfig.removeRecordBearerToken): _*)
+        .setHeader(
+          buildHeaders(
+            correlationId,
+            appConfig.hawkConfig.removeRecordBearerToken,
+            appConfig.hawkConfig.forwardedHost
+          ): _*
+        )
         .withBody(Json.toJson(RemoveEisRecordRequest(eori, recordId, actorId)))
         .execute(StatusHttpReader(correlationId, handleErrorResponse), ec)
     }

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/RequestAdviceConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/RequestAdviceConnector.scala
@@ -43,12 +43,18 @@ class RequestAdviceConnector @Inject() (
     hc: HeaderCarrier
   ): Future[Either[EisHttpErrorResponse, Int]] =
     withMetricsTimerAsync("tgp.advice.connector") { _ =>
-      val url = appConfig.eisConfig.requestAdviceUrl
+      val url = appConfig.pegaConfig.requestAdviceUrl
 
       val adviceEisRequest = RequestEisAccreditationRequest(request, dateTimeService.timestamp.asStringSeconds)
       httpClientV2
         .post(url"$url")
-        .setHeader(buildHeadersForAdvice(correlationId, appConfig.eisConfig.requestAdviceBearerToken): _*)
+        .setHeader(
+          buildHeadersForAdvice(
+            correlationId,
+            appConfig.pegaConfig.requestAdviceBearerToken,
+            appConfig.pegaConfig.forwardedHost
+          ): _*
+        )
         .withBody(Json.toJson(adviceEisRequest))
         .execute(StatusHttpReader(correlationId, handleErrorResponse), ec)
     }

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/UpdateRecordConnector.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/UpdateRecordConnector.scala
@@ -45,11 +45,17 @@ class UpdateRecordConnector @Inject() (
     correlationId: String
   )(implicit hc: HeaderCarrier): Future[Either[EisHttpErrorResponse, CreateOrUpdateRecordResponse]] =
     withMetricsTimerAsync("tgp.updaterecord.connector") { _ =>
-      val url = appConfig.eisConfig.updateRecordUrl
+      val url = appConfig.hawkConfig.updateRecordUrl
 
       httpClientV2
         .put(url"$url")
-        .setHeader(buildHeaders(correlationId, appConfig.eisConfig.updateRecordBearerToken): _*)
+        .setHeader(
+          buildHeaders(
+            correlationId,
+            appConfig.hawkConfig.updateRecordBearerToken,
+            appConfig.hawkConfig.forwardedHost
+          ): _*
+        )
         .withBody(toJson(payload))
         .execute(HttpReader[CreateOrUpdateRecordResponse](correlationId, handleErrorResponse), ec)
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -93,10 +93,10 @@ microservice {
       host = localhost
       port = 8500
     }
-    eis {
+    hawk {
         protocol = http
         host = localhost
-        port = 10903
+        port = 10908
         forwarded-host = "MDTP"
 
         get-records  = "/tgp/getrecords/v1"
@@ -104,14 +104,22 @@ microservice {
         remove-record  = "/tgp/removerecord/v1"
         update-record  = "/tgp/updaterecord/v1"
         maintain-profile  = "/tgp/maintainprofile/v1"
+        record-update-token = "c29tZS10b2tlbgo="
+        record-get-token = "c29tZS10b2tlbgo="
+        record-create-token = "c29tZS10b2tlbgo="
+        record-remove-token = "c29tZS10b2tlbgo="
+        maintain-profile-token = "c29tZS10b2tlbgo="
+    }
+    pega {
+        protocol = http
+        host = localhost
+        port = 10903
+        forwarded-host = "MDTP"
+
         request-advice  = "/tgp/createaccreditation/v1"
-        record-update-token = "dummyRecordUpdateBearerToken"
-        record-get-token = "dummyRecordGetBearerToken"
-        record-create-token = "dummyRecordCreateBearerToken"
-        record-remove-token = "dummyRecordRemoveBearerToken"
         request-advice-token = "dummyRequestAdviceBearerToken"
-        maintain-profile-token = "dummyMaintainProfileBearerToken"
-     }
+    }
+
   }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -96,7 +96,7 @@ microservice {
     hawk {
         protocol = http
         host = localhost
-        port = 10908
+        port = 10903
         forwarded-host = "MDTP"
 
         get-records  = "/tgp/getrecords/v1"

--- a/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/CreateRecordIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/CreateRecordIntegrationSpec.scala
@@ -36,8 +36,7 @@ class CreateRecordIntegrationSpec
   private val correlationId = "d677693e-9981-4ee3-8574-654981ebe606"
   private val url           = fullUrl("/traders/GB123456789001/records")
 
-  override def connectorPath: String = "/tgp/createrecord/v1"
-  override def connectorName: String = "eis"
+  override def hawkConnectorPath: Option[String] = Some("/tgp/createrecord/v1")
 
   override def beforeEach(): Unit = {
     reset(authConnector)
@@ -64,7 +63,7 @@ class CreateRecordIntegrationSpec
             createRecordResponseData.as[CreateOrUpdateRecordResponse]
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "with optional null request fields" in {
           stubForEis(CREATED, Some(createEisRecordResponseDataWithOptionalNullFields.toString()))
@@ -80,7 +79,7 @@ class CreateRecordIntegrationSpec
             createRecordResponseDataWithOptionalNullFields.as[CreateOrUpdateRecordResponse]
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "with optional condition null request fields" in {
           stubForEis(CREATED, Some(createEisRecordResponseDataWithConditionOptionalNullFields.toString()))
@@ -96,7 +95,7 @@ class CreateRecordIntegrationSpec
             createRecordResponseDataWithOptionalNullFields.as[CreateOrUpdateRecordResponse]
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "with optional some optional null request fields" in {
           stubForEis(CREATED, Some(createEisRecordResponseDataWithSomeOptionalNullFields.toString()))
@@ -112,7 +111,7 @@ class CreateRecordIntegrationSpec
             createRecordResponseDataWithSomeOptionalNullFields.as[CreateOrUpdateRecordResponse]
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "with only required fields" in {
           stubForEis(CREATED, Some(createRecordRequiredResponseData.toString()))
@@ -126,7 +125,7 @@ class CreateRecordIntegrationSpec
           response.status shouldBe CREATED
           response.json   shouldBe toJson(createRecordRequiredResponseData.as[CreateOrUpdateRecordResponse])
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
       }
       "valid but the integration call fails with response:" - {
@@ -146,7 +145,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Forbidden"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Not Found" in {
           stubForEis(NOT_FOUND)
@@ -164,7 +163,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Not Found"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Gateway" in {
           stubForEis(BAD_GATEWAY)
@@ -182,7 +181,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Bad Gateway"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Service Unavailable" in {
           stubForEis(SERVICE_UNAVAILABLE)
@@ -200,7 +199,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Service Unavailable"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error  with 201 errorCode" in {
           stubForEis(
@@ -221,7 +220,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Invalid Response Payload or Empty payload"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error  with 401 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("401", "Unauthorised")))
@@ -239,7 +238,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Unauthorized"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error  with 500 errorCode" in {
           stubForEis(
@@ -260,7 +259,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Internal Server Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 404 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("404", "Not Found")))
@@ -278,7 +277,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Not Found"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 405 errorCode" in {
           stubForEis(
@@ -299,7 +298,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Method Not Allowed"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 502 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("502", "Bad Gateway")))
@@ -317,7 +316,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Bad Gateway"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 503 errorCode" in {
           stubForEis(
@@ -338,7 +337,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Service Unavailable"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with one error detail" in {
           stubForEis(
@@ -381,7 +380,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with more than one error details" in {
           stubForEis(
@@ -430,7 +429,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with unexpected error" in {
           stubForEis(
@@ -473,7 +472,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with unable to parse the detail" in {
           stubForEis(
@@ -507,7 +506,7 @@ class CreateRecordIntegrationSpec
             "message"       -> s"Unable to parse fault detail for correlation Id: $correlationId"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with invalid json" in {
           stubForEis(
@@ -532,7 +531,7 @@ class CreateRecordIntegrationSpec
             "message"       -> "Unexpected Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
       }
       "invalid, specifically" - {
@@ -557,7 +556,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "missing required request field" in {
           val response = wsClient
@@ -580,7 +579,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "category field is out of range" in {
           val response = wsClient
@@ -603,7 +602,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "missing required field from assessment" in {
           stubForEis(
@@ -670,7 +669,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "supplementaryUnit is out of range" in {
           stubForEis(
@@ -713,7 +712,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "for optional fields" in {
           val response = wsClient
@@ -761,7 +760,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "for optional assessment array fields" in {
           val response = wsClient
@@ -804,7 +803,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "for mandatory fields actorId and comcode" in {
           val response = wsClient
@@ -832,7 +831,7 @@ class CreateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "forbidden with any of the following" - {
           "EORI number is not authorized" in {
@@ -850,7 +849,7 @@ class CreateRecordIntegrationSpec
               "message"       -> s"EORI number is incorrect"
             )
 
-            verifyThatDownstreamApiWasNotCalled()
+            verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
           }
 
           "incorrect enrolment key is used to authorise " in {
@@ -869,22 +868,25 @@ class CreateRecordIntegrationSpec
               "message"       -> s"EORI number is incorrect"
             )
 
-            verifyThatDownstreamApiWasNotCalled()
+            verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
           }
         }
       }
     }
   }
 
-  private def stubForEis(httpStatus: Int, responseBody: Option[String] = None) = stubFor(
-    post(urlEqualTo(s"$connectorPath"))
-      .willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withStatus(httpStatus)
-          .withBody(responseBody.orNull)
+  private def stubForEis(httpStatus: Int, responseBody: Option[String] = None) =
+    hawkConnectorPath.foreach { path =>
+      stubFor(
+        post(urlEqualTo(s"$path"))
+          .willReturn(
+            aResponse()
+              .withHeader("Content-Type", "application/json")
+              .withStatus(httpStatus)
+              .withBody(responseBody.orNull)
+          )
       )
-  )
+    }
 
   lazy val createRecordResponseData: JsValue =
     Json

--- a/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/GetMultipleRecordsIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/GetMultipleRecordsIntegrationSpec.scala
@@ -34,13 +34,12 @@ class GetMultipleRecordsIntegrationSpec
     with AuthTestSupport
     with BeforeAndAfterEach {
 
-  private val eori                   = "GB123456789001"
-  private val correlationId          = "d677693e-9981-4ee3-8574-654981ebe606"
-  private val dateTime               = Instant.parse("2021-12-17T09:30:47Z")
-  private val timestamp              = "Fri, 17 Dec 2021 09:30:47 GMT"
-  override def connectorPath: String = s"/tgp/getrecords/v1"
-  override def connectorName: String = "eis"
-  private val url                    = fullUrl(s"/traders/$eori/records")
+  private val eori                               = "GB123456789001"
+  private val correlationId                      = "d677693e-9981-4ee3-8574-654981ebe606"
+  private val dateTime                           = Instant.parse("2021-12-17T09:30:47Z")
+  private val timestamp                          = "Fri, 17 Dec 2021 09:30:47 GMT"
+  override def hawkConnectorPath: Option[String] = Some(s"/tgp/getrecords/v1")
+  private val url                                = fullUrl(s"/traders/$eori/records")
 
   override def beforeEach(): Unit = {
     reset(authConnector)
@@ -65,7 +64,7 @@ class GetMultipleRecordsIntegrationSpec
         response.status shouldBe OK
         response.json   shouldBe Json.toJson(getMultipleRecordResponseData.as[GetEisRecordsResponse])
 
-        verifyThatDownstreamApiWasCalled()
+        verifyThatDownstreamApiWasCalled(hawkConnectorPath)
       }
       "valid with optional query parameter lastUpdatedDate, page and size" in {
         stubForEis(OK, Some(getMultipleRecordResponseData.toString()), Some(dateTime.toString), Some(1), Some(1))
@@ -79,7 +78,7 @@ class GetMultipleRecordsIntegrationSpec
         response.status shouldBe OK
         response.json   shouldBe Json.toJson(getMultipleRecordResponseData.as[GetEisRecordsResponse])
 
-        verifyThatDownstreamApiWasCalled()
+        verifyThatDownstreamApiWasCalled(hawkConnectorPath)
       }
       "valid with optional query parameter page and size" in {
         stubForEis(OK, Some(getMultipleRecordResponseData.toString()), None, Some(1), Some(1))
@@ -93,7 +92,7 @@ class GetMultipleRecordsIntegrationSpec
         response.status shouldBe OK
         response.json   shouldBe Json.toJson(getMultipleRecordResponseData.as[GetEisRecordsResponse])
 
-        verifyThatDownstreamApiWasCalled()
+        verifyThatDownstreamApiWasCalled(hawkConnectorPath)
       }
       "valid with optional query parameter page" in {
         stubForEis(OK, Some(getMultipleRecordResponseData.toString()), None, Some(1), None)
@@ -107,7 +106,7 @@ class GetMultipleRecordsIntegrationSpec
         response.status shouldBe OK
         response.json   shouldBe Json.toJson(getMultipleRecordResponseData.as[GetEisRecordsResponse])
 
-        verifyThatDownstreamApiWasCalled()
+        verifyThatDownstreamApiWasCalled(hawkConnectorPath)
       }
       "valid with optional query parameter lastUpdatedDate" in {
         stubForEis(OK, Some(getMultipleRecordResponseData.toString()), Some(dateTime.toString))
@@ -121,7 +120,7 @@ class GetMultipleRecordsIntegrationSpec
         response.status shouldBe OK
         response.json   shouldBe Json.toJson(getMultipleRecordResponseData.as[GetEisRecordsResponse])
 
-        verifyThatDownstreamApiWasCalled()
+        verifyThatDownstreamApiWasCalled(hawkConnectorPath)
       }
       "valid but the integration call fails with response:" - {
         "Forbidden" in {
@@ -141,7 +140,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Forbidden"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Not Found" in {
           stubForEis(NOT_FOUND)
@@ -160,7 +159,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Not Found"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Method Not Allowed" in {
           stubForEis(METHOD_NOT_ALLOWED)
@@ -179,7 +178,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Method Not Allowed"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Service Unavailable" in {
           stubForEis(SERVICE_UNAVAILABLE)
@@ -198,7 +197,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Service Unavailable"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("500", "Internal Server Error")))
@@ -217,7 +216,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Internal Server Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 200 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("200", "Internal Server Error")))
@@ -236,7 +235,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Invalid Response Payload or Empty payload"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 400 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("400", "Internal Error Response")))
@@ -255,7 +254,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Internal Error Response"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 401 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("401", "Unauthorised")))
@@ -274,7 +273,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Unauthorized"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 404 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("404", "Not Found")))
@@ -293,7 +292,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Not Found"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 405 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("405", "Method Not Allowed")))
@@ -312,7 +311,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Method Not Allowed"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 502 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("502", "Bad Gateway")))
@@ -331,7 +330,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Bad Gateway"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 503 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("503", "Service Unavailable")))
@@ -350,7 +349,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Service Unavailable"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with unknown errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("501", "Not Implemented")))
@@ -369,7 +368,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Unknown Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with unexpected error" in {
           val eisErrorResponseBody = s"""
@@ -394,23 +393,24 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Unexpected Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
 
         "Bad Request with unexpected error" in {
-          stubFor(
-            get(urlEqualTo(s"$connectorPath/$eori"))
-              .withHeader("X-Forwarded-Host", equalTo("MDTP"))
-              .withHeader("X-Correlation-ID", equalTo("d677693e-9981-4ee3-8574-654981ebe606"))
-              .withHeader("Date", equalTo("Fri, 17 Dec 2021 09:30:47 GMT"))
-              .withHeader("Accept", equalTo("application/json"))
-              .withHeader("Authorization", equalTo("Bearer dummyRecordGetBearerToken"))
-              .withHeader("X-Client-ID", equalTo("tss"))
-              .willReturn(
-                aResponse()
-                  .withHeader("Content-Type", "application/json")
-                  .withStatus(BAD_REQUEST)
-                  .withBody(s"""
+          hawkConnectorPath.foreach { path =>
+            stubFor(
+              get(urlEqualTo(s"$path/$eori"))
+                .withHeader("X-Forwarded-Host", equalTo("MDTP"))
+                .withHeader("X-Correlation-ID", equalTo("d677693e-9981-4ee3-8574-654981ebe606"))
+                .withHeader("Date", equalTo("Fri, 17 Dec 2021 09:30:47 GMT"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Authorization", equalTo("Bearer c29tZS10b2tlbgo="))
+                .withHeader("X-Client-ID", equalTo("tss"))
+                .willReturn(
+                  aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withStatus(BAD_REQUEST)
+                    .withBody(s"""
                                |{
                                |  "errorDetail": {
                                |    "timestamp": "2023-09-14T11:29:18Z",
@@ -426,8 +426,9 @@ class GetMultipleRecordsIntegrationSpec
                                |  }
                                |}
                                |""".stripMargin)
-              )
-          )
+                )
+            )
+          }
 
           val response = await(
             wsClient
@@ -450,22 +451,23 @@ class GetMultipleRecordsIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with unable to parse the detail" in {
-          stubFor(
-            get(urlEqualTo(s"$connectorPath/$eori"))
-              .withHeader("X-Forwarded-Host", equalTo("MDTP"))
-              .withHeader("X-Correlation-ID", equalTo("d677693e-9981-4ee3-8574-654981ebe606"))
-              .withHeader("Date", equalTo("Fri, 17 Dec 2021 09:30:47 GMT"))
-              .withHeader("Accept", equalTo("application/json"))
-              .withHeader("Authorization", equalTo("Bearer dummyRecordGetBearerToken"))
-              .withHeader("X-Client-ID", equalTo("tss"))
-              .willReturn(
-                aResponse()
-                  .withHeader("Content-Type", "application/json")
-                  .withStatus(BAD_REQUEST)
-                  .withBody(s"""
+          hawkConnectorPath.foreach { path =>
+            stubFor(
+              get(urlEqualTo(s"$path/$eori"))
+                .withHeader("X-Forwarded-Host", equalTo("MDTP"))
+                .withHeader("X-Correlation-ID", equalTo("d677693e-9981-4ee3-8574-654981ebe606"))
+                .withHeader("Date", equalTo("Fri, 17 Dec 2021 09:30:47 GMT"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Authorization", equalTo("Bearer c29tZS10b2tlbgo="))
+                .withHeader("X-Client-ID", equalTo("tss"))
+                .willReturn(
+                  aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withStatus(BAD_REQUEST)
+                    .withBody(s"""
                                |{
                                |  "errorDetail": {
                                |    "timestamp": "2023-09-14T11:29:18Z",
@@ -479,8 +481,9 @@ class GetMultipleRecordsIntegrationSpec
                                |  }
                                |}
                                |""".stripMargin)
-              )
-          )
+                )
+            )
+          }
 
           val response = await(
             wsClient
@@ -496,28 +499,30 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> s"Unable to parse fault detail for correlation Id: $correlationId"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with invalid json" in {
-          stubFor(
-            get(urlEqualTo(s"$connectorPath/$eori"))
-              .withHeader("X-Forwarded-Host", equalTo("MDTP"))
-              .withHeader("X-Correlation-ID", equalTo("d677693e-9981-4ee3-8574-654981ebe606"))
-              .withHeader("Date", equalTo("Fri, 17 Dec 2021 09:30:47 GMT"))
-              .withHeader("Accept", equalTo("application/json"))
-              .withHeader("Authorization", equalTo("Bearer dummyRecordGetBearerToken"))
-              .withHeader("X-Client-ID", equalTo("tss"))
-              .willReturn(
-                aResponse()
-                  .withHeader("Content-Type", "application/json")
-                  .withStatus(BAD_REQUEST)
-                  .withBody(s"""
+          hawkConnectorPath.foreach { path =>
+            stubFor(
+              get(urlEqualTo(s"$path/$eori"))
+                .withHeader("X-Forwarded-Host", equalTo("MDTP"))
+                .withHeader("X-Correlation-ID", equalTo("d677693e-9981-4ee3-8574-654981ebe606"))
+                .withHeader("Date", equalTo("Fri, 17 Dec 2021 09:30:47 GMT"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("Authorization", equalTo("Bearer c29tZS10b2tlbgo="))
+                .withHeader("X-Client-ID", equalTo("tss"))
+                .willReturn(
+                  aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withStatus(BAD_REQUEST)
+                    .withBody(s"""
                                | {
                                |    "invalid": "error"
                                |  }
                                |""".stripMargin)
-              )
-          )
+                )
+            )
+          }
 
           val response = await(
             wsClient
@@ -533,7 +538,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> "Unexpected Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
       }
       "invalid with missing mandatory header" in {
@@ -557,7 +562,7 @@ class GetMultipleRecordsIntegrationSpec
           )
         )
 
-        verifyThatDownstreamApiWasNotCalled()
+        verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
       }
       "forbidden with any of the following" - {
         "EORI number is not authorized" in {
@@ -575,7 +580,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> s"EORI number is incorrect"
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
 
         "incorrect enrolment key is used to authorise " in {
@@ -594,7 +599,7 @@ class GetMultipleRecordsIntegrationSpec
             "message"       -> s"EORI number is incorrect"
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
       }
     }
@@ -624,26 +629,27 @@ class GetMultipleRecordsIntegrationSpec
     lastUpdatedDate: Option[String] = None,
     page: Option[Int] = None,
     size: Option[Int] = None
-  ) = {
+  ) =
+    hawkConnectorPath.foreach { path =>
+      val uri =
+        uri"$path/$eori?lastUpdatedDate=$lastUpdatedDate&page=$page&size=$size"
 
-    val uri =
-      uri"$connectorPath/$eori?lastUpdatedDate=$lastUpdatedDate&page=$page&size=$size"
-    stubFor(
-      get(urlEqualTo(s"$uri"))
-        .withHeader("X-Forwarded-Host", equalTo("MDTP"))
-        .withHeader("X-Correlation-ID", equalTo(correlationId))
-        .withHeader("Date", equalTo(timestamp))
-        .withHeader("Accept", equalTo("application/json"))
-        .withHeader("Authorization", equalTo("Bearer dummyRecordGetBearerToken"))
-        .withHeader("X-Client-ID", equalTo("tss"))
-        .willReturn(
-          aResponse()
-            .withHeader("Content-Type", "application/json")
-            .withStatus(httpStatus)
-            .withBody(body.orNull)
-        )
-    )
-  }
+      stubFor(
+        get(urlEqualTo(s"$uri"))
+          .withHeader("X-Forwarded-Host", equalTo("MDTP"))
+          .withHeader("X-Correlation-ID", equalTo(correlationId))
+          .withHeader("Date", equalTo(timestamp))
+          .withHeader("Accept", equalTo("application/json"))
+          .withHeader("Authorization", equalTo("Bearer c29tZS10b2tlbgo="))
+          .withHeader("X-Client-ID", equalTo("tss"))
+          .willReturn(
+            aResponse()
+              .withHeader("Content-Type", "application/json")
+              .withStatus(httpStatus)
+              .withBody(body.orNull)
+          )
+      )
+    }
 
   private def eisErrorResponse(errorCode: String, errorMessage: String): String =
     Json

--- a/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/GetSingleRecordIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/GetSingleRecordIntegrationSpec.scala
@@ -33,13 +33,12 @@ class GetSingleRecordIntegrationSpec
     with GetRecordsDataSupport
     with BeforeAndAfterEach {
 
-  private val eori                   = "GB123456789001"
-  private val recordId               = "8ebb6b04-6ab0-4fe2-ad62-e6389a8a204f"
-  private val correlationId          = "d677693e-9981-4ee3-8574-654981ebe606"
-  private val dateTime               = "2021-12-17T09:30:47.456Z"
-  private val url                    = fullUrl(s"/traders/$eori/records/$recordId")
-  override def connectorPath: String = s"/tgp/getrecords/v1"
-  override def connectorName: String = "eis"
+  private val eori                               = "GB123456789001"
+  private val recordId                           = "8ebb6b04-6ab0-4fe2-ad62-e6389a8a204f"
+  private val correlationId                      = "d677693e-9981-4ee3-8574-654981ebe606"
+  private val dateTime                           = "2021-12-17T09:30:47.456Z"
+  private val url                                = fullUrl(s"/traders/$eori/records/$recordId")
+  override def hawkConnectorPath: Option[String] = Some(s"/tgp/getrecords/v1")
 
   override def beforeEach(): Unit = {
     reset(authConnector)
@@ -66,7 +65,7 @@ class GetSingleRecordIntegrationSpec
           getEisRecordsResponseDataWithNiphlStrippedOfDashes.as[GetEisRecordsResponse].goodsItemRecords.head
         )
 
-        verifyThatDownstreamApiWasCalled()
+        verifyThatDownstreamApiWasCalled(hawkConnectorPath)
       }
 
       "valid but the integration call fails with response:" - {
@@ -87,7 +86,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Forbidden"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Not Found" in {
           stubForEis(NOT_FOUND)
@@ -106,7 +105,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Not Found"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Method Not Allowed" in {
           stubForEis(METHOD_NOT_ALLOWED)
@@ -125,7 +124,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Method Not Allowed"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Service Unavailable" in {
           stubForEis(SERVICE_UNAVAILABLE)
@@ -144,7 +143,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Service Unavailable"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("500", "Internal Server Error")))
@@ -163,7 +162,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Internal Server Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 200 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("200", "Internal Server Error")))
@@ -182,7 +181,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Invalid Response Payload or Empty payload"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 400 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("400", "Internal Error Response")))
@@ -201,7 +200,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Internal Error Response"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 401 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("401", "Unauthorised")))
@@ -220,7 +219,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Unauthorized"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 404 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("404", "Not Found")))
@@ -239,7 +238,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Not Found"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 405 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("405", "Method Not Allowed")))
@@ -258,7 +257,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Method Not Allowed"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 502 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("502", "Bad Gateway")))
@@ -277,7 +276,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Bad Gateway"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 503 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("503", "Service Unavailable")))
@@ -296,7 +295,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Service Unavailable"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with unknown errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("501", "Not Implemented")))
@@ -315,7 +314,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Unknown Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with unexpected error" in {
           val eisErrorResponseBody = s"""
@@ -340,7 +339,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Unexpected Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
 
         "Bad Request if recordId is invalid" in {
@@ -366,15 +365,16 @@ class GetSingleRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "Bad Request with unexpected error if error code is ot supported" in {
-          stubFor(
-            get(urlEqualTo(s"$connectorPath/$eori/$recordId"))
-              .willReturn(
-                aResponse()
-                  .withStatus(BAD_REQUEST)
-                  .withBody(s"""
+          hawkConnectorPath.foreach { path =>
+            stubFor(
+              get(urlEqualTo(s"$path/$eori/$recordId"))
+                .willReturn(
+                  aResponse()
+                    .withStatus(BAD_REQUEST)
+                    .withBody(s"""
                                |{
                                |  "errorDetail": {
                                |    "timestamp": "2023-09-14T11:29:18Z",
@@ -390,8 +390,9 @@ class GetSingleRecordIntegrationSpec
                                |  }
                                |}
                                |""".stripMargin)
-              )
-          )
+                )
+            )
+          }
 
           val response = await(
             wsClient
@@ -414,15 +415,16 @@ class GetSingleRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with unable to parse the detail" in {
-          stubFor(
-            get(urlEqualTo(s"$connectorPath/$eori/$recordId"))
-              .willReturn(
-                aResponse()
-                  .withStatus(BAD_REQUEST)
-                  .withBody(s"""
+          hawkConnectorPath.foreach { path =>
+            stubFor(
+              get(urlEqualTo(s"$path/$eori/$recordId"))
+                .willReturn(
+                  aResponse()
+                    .withStatus(BAD_REQUEST)
+                    .withBody(s"""
                                |{
                                |  "errorDetail": {
                                |    "timestamp": "2023-09-14T11:29:18Z",
@@ -436,8 +438,9 @@ class GetSingleRecordIntegrationSpec
                                |  }
                                |}
                                |""".stripMargin)
-              )
-          )
+                )
+            )
+          }
 
           val response = await(
             wsClient
@@ -453,21 +456,23 @@ class GetSingleRecordIntegrationSpec
             "message"       -> s"Unable to parse fault detail for correlation Id: $correlationId"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with invalid json" in {
-          stubFor(
-            get(urlEqualTo(s"$connectorPath/$eori/$recordId"))
-              .willReturn(
-                aResponse()
-                  .withStatus(BAD_REQUEST)
-                  .withBody(s"""
+          hawkConnectorPath.foreach { path =>
+            stubFor(
+              get(urlEqualTo(s"$path/$eori/$recordId"))
+                .willReturn(
+                  aResponse()
+                    .withStatus(BAD_REQUEST)
+                    .withBody(s"""
                                | {
                                |    "invalid": "error"
                                |  }
                                |""".stripMargin)
-              )
-          )
+                )
+            )
+          }
 
           val response = await(
             wsClient
@@ -483,7 +488,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> "Unexpected Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
       }
       "invalid with missing mandatory header" in {
@@ -507,7 +512,7 @@ class GetSingleRecordIntegrationSpec
           )
         )
 
-        verifyThatDownstreamApiWasNotCalled()
+        verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
       }
       "forbidden with any of the following" - {
         "EORI number is not authorized" in {
@@ -525,7 +530,7 @@ class GetSingleRecordIntegrationSpec
             "message"       -> s"EORI number is incorrect"
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
 
         "incorrect enrolment key is used to authorise " in {
@@ -544,20 +549,23 @@ class GetSingleRecordIntegrationSpec
             "message"       -> s"EORI number is incorrect"
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
       }
     }
   }
 
-  private def stubForEis(httpStatus: Int, body: Option[String] = None) = stubFor(
-    get(urlEqualTo(s"$connectorPath/$eori/$recordId"))
-      .willReturn(
-        aResponse()
-          .withStatus(httpStatus)
-          .withBody(body.orNull)
+  private def stubForEis(httpStatus: Int, body: Option[String] = None) =
+    hawkConnectorPath.foreach { path =>
+      stubFor(
+        get(urlEqualTo(s"$path/$eori/$recordId"))
+          .willReturn(
+            aResponse()
+              .withStatus(httpStatus)
+              .withBody(body.orNull)
+          )
       )
-  )
+    }
 
   private def eisErrorResponse(errorCode: String, errorMessage: String): String =
     Json

--- a/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/RemoveRecordIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/RemoveRecordIntegrationSpec.scala
@@ -32,15 +32,14 @@ class RemoveRecordIntegrationSpec
     with AuthTestSupport
     with BeforeAndAfterEach {
 
-  private val eori                   = "GB123456789001"
-  private val actorId                = "GB123456789001"
-  private val recordId               = "8ebb6b04-6ab0-4fe2-ad62-e6389a8a204f"
-  private val correlationId          = "d677693e-9981-4ee3-8574-654981ebe606"
-  private val dateTime               = "2021-12-17T09:30:47.456Z"
-  private val timestamp              = "Fri, 17 Dec 2021 09:30:47 GMT"
-  private val url                    = fullUrl(s"/traders/$eori/records/$recordId?actorId=$actorId")
-  override def connectorPath: String = s"/tgp/removerecord/v1"
-  override def connectorName: String = "eis"
+  private val eori                               = "GB123456789001"
+  private val actorId                            = "GB123456789001"
+  private val recordId                           = "8ebb6b04-6ab0-4fe2-ad62-e6389a8a204f"
+  private val correlationId                      = "d677693e-9981-4ee3-8574-654981ebe606"
+  private val dateTime                           = "2021-12-17T09:30:47.456Z"
+  private val timestamp                          = "Fri, 17 Dec 2021 09:30:47 GMT"
+  private val url                                = fullUrl(s"/traders/$eori/records/$recordId?actorId=$actorId")
+  override def hawkConnectorPath: Option[String] = Some(s"/tgp/removerecord/v1")
 
   override def beforeEach(): Unit = {
     reset(authConnector)
@@ -63,7 +62,7 @@ class RemoveRecordIntegrationSpec
 
         response.status shouldBe NO_CONTENT
 
-        verifyThatDownstreamApiWasCalled()
+        verifyThatDownstreamApiWasCalled(hawkConnectorPath)
       }
 
       "valid but the integration call fails with response:" - {
@@ -84,7 +83,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Forbidden"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Not Found" in {
           stubForEis(NOT_FOUND, removeEisRecordRequest)
@@ -102,7 +101,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Not Found"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Gateway" in {
           stubForEis(BAD_GATEWAY, removeEisRecordRequest)
@@ -120,7 +119,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Bad Gateway"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Service Unavailable" in {
           stubForEis(SERVICE_UNAVAILABLE, removeEisRecordRequest)
@@ -138,7 +137,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Service Unavailable"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error  with 401 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, removeEisRecordRequest, Some(eisErrorResponse("401", "Unauthorised")))
@@ -156,7 +155,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Unauthorized"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error  with 500 errorCode" in {
           stubForEis(
@@ -178,7 +177,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Internal Server Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 404 errorCode" in {
           stubForEis(
@@ -200,7 +199,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Not Found"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 405 errorCode" in {
           stubForEis(
@@ -222,7 +221,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Method Not Allowed"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 502 errorCode" in {
           stubForEis(
@@ -244,7 +243,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Bad Gateway"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 503 errorCode" in {
           stubForEis(
@@ -266,7 +265,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Service Unavailable"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with one error detail" in {
           stubForEis(
@@ -310,7 +309,7 @@ class RemoveRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with more than one error details" in {
           stubForEis(
@@ -372,7 +371,7 @@ class RemoveRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with unexpected error" in {
           stubForEis(
@@ -416,7 +415,7 @@ class RemoveRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with unable to parse the detail" in {
           stubForEis(
@@ -451,7 +450,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Unable to parse fault detail for correlation Id: d677693e-9981-4ee3-8574-654981ebe606"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with invalid json" in {
           stubForEis(
@@ -477,7 +476,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> "Unexpected Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
       }
       "invalid, specifically" - {
@@ -502,7 +501,7 @@ class RemoveRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
       }
       "forbidden with any of the following" - {
@@ -521,7 +520,7 @@ class RemoveRecordIntegrationSpec
             "message"       -> s"EORI number is incorrect"
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
 
         "incorrect enrolment key is used to authorise " in {
@@ -540,29 +539,32 @@ class RemoveRecordIntegrationSpec
             "message"       -> s"EORI number is incorrect"
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
       }
     }
   }
 
-  private def stubForEis(httpStatus: Int, requestBody: String, responseBody: Option[String] = None) = stubFor(
-    put(urlEqualTo(s"$connectorPath"))
-      .withRequestBody(equalToJson(requestBody))
-      .withHeader("Content-Type", equalTo("application/json"))
-      .withHeader("X-Forwarded-Host", equalTo("MDTP"))
-      .withHeader("X-Correlation-ID", equalTo(correlationId))
-      .withHeader("Date", equalTo(timestamp))
-      .withHeader("Accept", equalTo("application/json"))
-      .withHeader("Authorization", equalTo("Bearer dummyRecordRemoveBearerToken"))
-      .withHeader("X-Client-ID", equalTo("tss"))
-      .willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withStatus(httpStatus)
-          .withBody(responseBody.orNull)
+  private def stubForEis(httpStatus: Int, requestBody: String, responseBody: Option[String] = None) =
+    hawkConnectorPath.foreach { path =>
+      stubFor(
+        put(urlEqualTo(s"$path"))
+          .withRequestBody(equalToJson(requestBody))
+          .withHeader("Content-Type", equalTo("application/json"))
+          .withHeader("X-Forwarded-Host", equalTo("MDTP"))
+          .withHeader("X-Correlation-ID", equalTo(correlationId))
+          .withHeader("Date", equalTo(timestamp))
+          .withHeader("Accept", equalTo("application/json"))
+          .withHeader("Authorization", equalTo("Bearer c29tZS10b2tlbgo="))
+          .withHeader("X-Client-ID", equalTo("tss"))
+          .willReturn(
+            aResponse()
+              .withHeader("Content-Type", "application/json")
+              .withStatus(httpStatus)
+              .withBody(responseBody.orNull)
+          )
       )
-  )
+    }
 
   private def eisErrorResponse(errorCode: String, errorMessage: String): String =
     Json

--- a/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/UpdateRecordIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/UpdateRecordIntegrationSpec.scala
@@ -33,14 +33,13 @@ class UpdateRecordIntegrationSpec
     with AuthTestSupport
     with BeforeAndAfterEach {
 
-  private val eori                   = "GB123456789001"
-  private val recordId               = "8ebb6b04-6ab0-4fe2-ad62-e6389a8a204f"
-  val correlationId                  = "d677693e-9981-4ee3-8574-654981ebe606"
-  val dateTime                       = "2021-12-17T09:30:47.456Z"
-  val timestamp                      = "Fri, 17 Dec 2021 09:30:47 GMT"
-  private val url                    = fullUrl(s"/traders/$eori/records/$recordId")
-  override def connectorPath: String = "/tgp/updaterecord/v1"
-  override def connectorName: String = "eis"
+  private val eori                               = "GB123456789001"
+  private val recordId                           = "8ebb6b04-6ab0-4fe2-ad62-e6389a8a204f"
+  val correlationId                              = "d677693e-9981-4ee3-8574-654981ebe606"
+  val dateTime                                   = "2021-12-17T09:30:47.456Z"
+  val timestamp                                  = "Fri, 17 Dec 2021 09:30:47 GMT"
+  private val url                                = fullUrl(s"/traders/$eori/records/$recordId")
+  override def hawkConnectorPath: Option[String] = Some("/tgp/updaterecord/v1")
 
   override def beforeEach(): Unit = {
     reset(authConnector)
@@ -65,7 +64,7 @@ class UpdateRecordIntegrationSpec
           response.status shouldBe OK
           response.json   shouldBe toJson(updateRecordResponseData.as[CreateOrUpdateRecordResponse])
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "with optional null request fields" in {
           stubForEis(
@@ -82,7 +81,7 @@ class UpdateRecordIntegrationSpec
           response.status shouldBe OK
           response.json   shouldBe toJson(updateRecordResponseDataWithOptionalFields.as[CreateOrUpdateRecordResponse])
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "with optional condition null request fields" in {
           stubForEis(
@@ -99,7 +98,7 @@ class UpdateRecordIntegrationSpec
           response.status shouldBe OK
           response.json   shouldBe toJson(updateRecordResponseDataWithOptionalFields.as[CreateOrUpdateRecordResponse])
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "with optional some optional null request fields" in {
           stubForEis(
@@ -116,7 +115,7 @@ class UpdateRecordIntegrationSpec
           response.status shouldBe OK
           response.json   shouldBe toJson(updateRecordResponseDataWithSomeOptionalFields.as[CreateOrUpdateRecordResponse])
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "with only required fields" in {
           stubForEis(OK, Some(updateRecordRequiredResponseData.toString()))
@@ -130,7 +129,7 @@ class UpdateRecordIntegrationSpec
           response.status shouldBe OK
           response.json   shouldBe toJson(updateRecordRequiredResponseData.as[CreateOrUpdateRecordResponse])
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
       }
       "valid but the integration call fails with response:" - {
@@ -150,7 +149,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Forbidden"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Not Found" in {
           stubForEis(NOT_FOUND)
@@ -168,7 +167,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Not Found"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Gateway" in {
           stubForEis(BAD_GATEWAY)
@@ -186,7 +185,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Bad Gateway"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Service Unavailable" in {
           stubForEis(SERVICE_UNAVAILABLE)
@@ -204,7 +203,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Service Unavailable"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error  with 201 errorCode" in {
           stubForEis(
@@ -225,7 +224,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Invalid Response Payload or Empty payload"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error  with 401 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("401", "Unauthorised")))
@@ -243,7 +242,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Unauthorized"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error  with 500 errorCode" in {
           stubForEis(
@@ -264,7 +263,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Internal Server Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 404 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("404", "Not Found")))
@@ -282,7 +281,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Not Found"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 405 errorCode" in {
           stubForEis(
@@ -303,7 +302,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Method Not Allowed"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 502 errorCode" in {
           stubForEis(INTERNAL_SERVER_ERROR, Some(eisErrorResponse("502", "Bad Gateway")))
@@ -321,7 +320,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Bad Gateway"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Internal Server Error with 503 errorCode" in {
           stubForEis(
@@ -342,7 +341,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Service Unavailable"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with one error detail" in {
           stubForEis(
@@ -385,7 +384,7 @@ class UpdateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with more than one error details" in {
           stubForEis(
@@ -434,7 +433,7 @@ class UpdateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with unexpected error" in {
           stubForEis(
@@ -477,7 +476,7 @@ class UpdateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with unable to parse the detail" in {
           stubForEis(
@@ -511,7 +510,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> s"Unable to parse fault detail for correlation Id: $correlationId"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
         "Bad Request with invalid json" in {
           stubForEis(
@@ -536,7 +535,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> "Unexpected Error"
           )
 
-          verifyThatDownstreamApiWasCalled()
+          verifyThatDownstreamApiWasCalled(hawkConnectorPath)
         }
       }
       "invalid, specifically" - {
@@ -561,7 +560,7 @@ class UpdateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "missing required request field" in {
           val response = wsClient
@@ -584,7 +583,7 @@ class UpdateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "for optional fields" in {
           val response = wsClient
@@ -632,7 +631,7 @@ class UpdateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "for optional assessment array fields" in {
           val response = wsClient
@@ -670,7 +669,7 @@ class UpdateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
         "for a mandatory field actorId and an optional filed comcode" in {
           val response = wsClient
@@ -698,7 +697,7 @@ class UpdateRecordIntegrationSpec
             )
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
       }
       "forbidden with any of the following" - {
@@ -717,7 +716,7 @@ class UpdateRecordIntegrationSpec
             "message"       -> s"EORI number is incorrect"
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
 
         "incorrect enrolment key is used to authorise " in {
@@ -736,21 +735,24 @@ class UpdateRecordIntegrationSpec
             "message"       -> s"EORI number is incorrect"
           )
 
-          verifyThatDownstreamApiWasNotCalled()
+          verifyThatDownstreamApiWasNotCalled(hawkConnectorPath)
         }
       }
     }
   }
 
-  private def stubForEis(httpStatus: Int, responseBody: Option[String] = None) = stubFor(
-    put(urlEqualTo(s"$connectorPath"))
-      .willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withStatus(httpStatus)
-          .withBody(responseBody.orNull)
+  private def stubForEis(httpStatus: Int, responseBody: Option[String] = None) =
+    hawkConnectorPath.foreach { path =>
+      stubFor(
+        put(urlEqualTo(s"$path"))
+          .willReturn(
+            aResponse()
+              .withHeader("Content-Type", "application/json")
+              .withStatus(httpStatus)
+              .withBody(responseBody.orNull)
+          )
       )
-  )
+    }
 
   lazy val updateRecordResponseData: JsValue =
     Json

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/support/BaseConnectorSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/support/BaseConnectorSpec.scala
@@ -26,7 +26,7 @@ import play.api.http.MimeTypes
 import play.api.mvc.Result
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import uk.gov.hmrc.tradergoodsprofilesrouter.config.{AppConfig, EISInstanceConfig}
+import uk.gov.hmrc.tradergoodsprofilesrouter.config.{AppConfig, HawkInstanceConfig, PegaInstanceConfig}
 import uk.gov.hmrc.tradergoodsprofilesrouter.connectors.EisHttpReader.HttpReader
 import uk.gov.hmrc.tradergoodsprofilesrouter.models.response.eis.GetEisRecordsResponse
 import uk.gov.hmrc.tradergoodsprofilesrouter.service.DateTimeService
@@ -44,9 +44,13 @@ trait BaseConnectorSpec extends PlaySpec with BeforeAndAfterEach with EitherValu
   val requestBuilder: RequestBuilder   = mock[RequestBuilder]
   val dateTimeService: DateTimeService = mock[DateTimeService]
 
-  def expectedHeader(correlationId: String, accessToken: String): Seq[(String, String)] = Seq(
+  def expectedHeader(
+    correlationId: String,
+    accessToken: String,
+    forwardedHost: String = "MDTP"
+  ): Seq[(String, String)] = Seq(
     "X-Correlation-ID" -> correlationId,
-    "X-Forwarded-Host" -> "MDTP",
+    "X-Forwarded-Host" -> forwardedHost,
     "Accept"           -> MimeTypes.JSON,
     "Date"             -> "Sun, 12 May 2024 12:15:15 GMT",
     "X-Client-ID"      -> "TSS",
@@ -54,36 +58,49 @@ trait BaseConnectorSpec extends PlaySpec with BeforeAndAfterEach with EitherValu
     "Content-Type"     -> MimeTypes.JSON
   )
 
-  def expectedHeaderForGetMethod(correlationId: String, accessToken: String): Seq[(String, String)] = Seq(
+  def expectedHeaderForGetMethod(
+    correlationId: String,
+    accessToken: String,
+    forwardedHost: String = "MDTP"
+  ): Seq[(String, String)] = Seq(
     "X-Correlation-ID" -> correlationId,
-    "X-Forwarded-Host" -> "MDTP",
+    "X-Forwarded-Host" -> forwardedHost,
     "Accept"           -> MimeTypes.JSON,
     "Date"             -> "Sun, 12 May 2024 12:15:15 GMT",
     "X-Client-ID"      -> "TSS",
     "Authorization"    -> s"Bearer $accessToken"
   )
 
-  def setUpAppConfig(): Unit =
-    when(appConfig.eisConfig).thenReturn(
-      new EISInstanceConfig(
-        "http",
-        "localhost",
-        1234,
-        "/tgp/getrecords/v1",
-        "/tgp/createrecord/v1",
-        "/tgp/removerecord/v1",
-        "/tgp/updaterecord/v1",
-        "/tgp/maintainprofile/v1",
-        "/tgp/createaccreditation/v1",
-        "MDTP",
-        "dummyRecordUpdateBearerToken",
-        "dummyRecordGetBearerToken",
-        "dummyRecordCreateBearerToken",
-        "dummyRecordRemoveBearerToken",
-        "dummyAccreditationCreateBearerToken",
-        "dummyMaintainProfileBearerToken"
-      )
+  def setUpAppConfig(): Unit = {
+    val hawkConfig = new HawkInstanceConfig(
+      protocol = "http",
+      host = "localhost",
+      port = 1234,
+      getRecords = "/tgp/getrecords/v1",
+      createRecord = "/tgp/createrecord/v1",
+      removeRecord = "/tgp/removerecord/v1",
+      updateRecord = "/tgp/updaterecord/v1",
+      maintainProfile = "/tgp/maintainprofile/v1",
+      forwardedHost = "MDTP",
+      updateRecordToken = "dummyRecordUpdateBearerToken",
+      recordGetToken = "dummyRecordGetBearerToken",
+      recordCreateToken = "dummyRecordCreateBearerToken",
+      recordRemoveToken = "dummyRecordRemoveBearerToken",
+      maintainProfileToken = "dummyMaintainProfileBearerToken"
     )
+
+    val pegaConfig = new PegaInstanceConfig(
+      protocol = "http",
+      host = "localhost",
+      port = 1234,
+      requestAdvice = "/tgp/createaccreditation/v1",
+      forwardedHost = "MDTP",
+      requestAdviceToken = "dummyAccreditationCreateBearerToken"
+    )
+
+    when(appConfig.hawkConfig).thenReturn(hawkConfig)
+    when(appConfig.pegaConfig).thenReturn(pegaConfig)
+  }
 
   def verifyExecuteWithParams(expectedCorrelationId: String): Assertion = {
     val captor = ArgCaptor[HttpReader[Either[Result, GetEisRecordsResponse]]]


### PR DESCRIPTION
### Description
- [x] Split the EIS configuration into separate HAWK and PEGA paths.
- [x] Updated the `BaseConnector` to handle  both HAWK and PEGA Instances.
- [x] Modified the `BaseIntegrationWithConnectorSpec `so we can test both connectors on the same test like `RequestAdviceIntegrationSpec`.
- [x] Updated all the integration test to reflect the changes.