### PR TITLE
TGP-2358: Add Level 2 validation to commodity code

### DIFF
--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/controllers/action/ValidationRules.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/controllers/action/ValidationRules.scala
@@ -155,7 +155,7 @@ object ValidationRules {
 
   private val WithdrawReasonCharLimit = 512
   private val actorIdPattern: Regex   = raw"[A-Z]{2}\d{12,15}".r
-  private val comcodePattern: Regex   = raw".{6}(.{2}(.{2})?)?".r
+  private val comcodePattern: Regex   = """^([0-9]{6}|[0-9]{8}|[0-9]{10})$""".r
   private val niphlPattern: Regex     = raw"([0-9]{4,6}|[a-zA-Z]{1,2}[0-9]{5})".r
 
   def isValidCountryCode(rawCountryCode: String): Boolean =

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/controllers/action/ValidationRulesSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/controllers/action/ValidationRulesSpec.scala
@@ -310,13 +310,22 @@ class ValidationRulesSpec extends PlaySpec with ScalaFutures with EitherValues w
   }
 
   "isValidComcode" should {
-    "return true for a valid comcode" in {
+    "return true for a valid comcode with only digits and valid length of 6, 8 or 10" in {
       isValidComcode("123456") mustBe true
       isValidComcode("12345678") mustBe true
       isValidComcode("1234567890") mustBe true
     }
-    "return false if comcode is not valid" in {
-      isValidComcode("111") mustBe false
+    "return false for an invalid comcode with non-digit characters" in {
+      isValidComcode("12345a") mustBe false
+      isValidComcode("1234!8") mustBe false
+      isValidComcode("1234_8") mustBe false
+    }
+
+    "return false for an invalid comcode with incorrect length" in {
+      isValidComcode("1234") mustBe false
+      isValidComcode("1234567") mustBe false
+      isValidComcode("123456789") mustBe false
+      isValidComcode("12345678901") mustBe false
     }
   }
 


### PR DESCRIPTION
- [x] Update `comcode` validation to allow only 6, 8, or 10 digits