### PR TITLE
Address security vulnerability CVE-2025-48734

### DIFF
--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/EisHttpReader.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/connectors/EisHttpReader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/models/Retries.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/models/Retries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/eis/MaintainProfileResponse.scala
+++ b/app/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/eis/MaintainProfileResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/BaseIntegrationWithConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/tradergoodsprofilesrouter/BaseIntegrationWithConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   val compile = Seq(
     "uk.gov.hmrc"      %% "bootstrap-backend-play-30" % bootstrapVersion,
     "org.typelevel"    %% "cats-core"                 % catsVersion,
-    "commons-validator" % "commons-validator"         % "1.9.0",
+    "commons-validator" % "commons-validator"         % "1.10.1",
     "com.beachape"     %% "enumeratum-play"           % "1.9.0"
   )
 

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/RetriesSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/RetriesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/CreateProfileEisRequestSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/CreateProfileEisRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/CreateProfileRequestSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/CreateProfileRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/CreateRecordRequestSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/CreateRecordRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/MaintainProfileRequestSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/MaintainProfileRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/PatchRecordRequestSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/PatchRecordRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/RemoveEIsRecordRequestSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/RemoveEIsRecordRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/RemoveRecordRequestSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/RemoveRecordRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/WithdrawAdviceSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/request/WithdrawAdviceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/AccreditationStatusSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/AccreditationStatusSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/AuditGetRecordsResponseSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/AuditGetRecordsResponseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/AuditOutcomeSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/AuditOutcomeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/CorrelationIdSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/CorrelationIdSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/GetRecordsResponseSpec.scala
+++ b/test/uk/gov/hmrc/tradergoodsprofilesrouter/models/response/GetRecordsResponseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Catalogue has highlighted a security vulnerability (CVE-2025-48734). 

The vulnerability is in commons-beanutils.commons-beanutils-1.9.4.jar which is pulled in by commons-validator:commons-validator:1.9.0. 

The fix is to update commons-beanutils to version 1.11.0. 

commons-validator version 1.10.1 updates it's commons-beanutils dependency to version 1.11.0

